### PR TITLE
feat(core): add PPSSPP support with pointer chains and LE memory reads

### DIFF
--- a/app/src/main/java/com/emulnk/bridge/EmuLinkBridge.kt
+++ b/app/src/main/java/com/emulnk/bridge/EmuLinkBridge.kt
@@ -197,7 +197,6 @@ class EmuLinkBridge(
         } catch (e: Exception) {
             viewModel.addDebugLog("Sound Error: ${e.message}")
             mediaPlayer.release()
-            // Clean up temp file on error
             if (file.name.startsWith("dev_sound_")) {
                 file.delete()
             }

--- a/app/src/main/java/com/emulnk/core/Constants.kt
+++ b/app/src/main/java/com/emulnk/core/Constants.kt
@@ -26,6 +26,9 @@ object MemoryConstants {
 
     /** Maximum valid 32-bit address */
     const val MAX_ADDRESS = 0xFFFFFFFFL
+
+    /** Maximum depth for multi-level pointer chains */
+    const val MAX_POINTER_CHAIN_DEPTH = 10
 }
 
 object UiConstants {

--- a/app/src/main/java/com/emulnk/data/ConfigManager.kt
+++ b/app/src/main/java/com/emulnk/data/ConfigManager.kt
@@ -222,6 +222,24 @@ class ConfigManager(private val context: android.content.Context) {
         }
     }
 
+    fun resolveProfileId(gameId: String): String? {
+        if (!profilesDir.exists()) return null
+        val files = profilesDir.listFiles { f -> f.extension == "json" } ?: return null
+        for (file in files) {
+            val profile = parseProfile(file) ?: continue
+            // Gson bypasses Kotlin default values — gameIds can be null at runtime
+            if (profile.gameIds?.any { it.equals(gameId, ignoreCase = true) } == true) {
+                return profile.id
+            }
+        }
+        // Fallback: prefix matching (GameCube/Wii style)
+        val baseName = files.map { it.nameWithoutExtension }
+        if (gameId.length >= 3) {
+            baseName.find { gameId.startsWith(it, ignoreCase = true) }?.let { return it }
+        }
+        return null
+    }
+
     fun loadProfile(profileId: String): ProfileConfig? {
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "Loading profile for: $profileId")

--- a/app/src/main/java/com/emulnk/model/ConsoleConfig.kt
+++ b/app/src/main/java/com/emulnk/model/ConsoleConfig.kt
@@ -9,5 +9,6 @@ data class ConsoleConfig(
     val packageNames: List<String> = emptyList(), // Support multiple packages for forks
     val console: String, // GCN, WII, PSP, etc.
     val port: Int,
-    val idAddress: String
+    val idAddress: String,
+    val idSize: Int = 6
 )

--- a/app/src/main/java/com/emulnk/model/ProfileConfig.kt
+++ b/app/src/main/java/com/emulnk/model/ProfileConfig.kt
@@ -7,6 +7,7 @@ data class ProfileConfig(
     val id: String,
     val name: String,
     val platform: String,
+    val gameIds: List<String> = emptyList(),
     val dataPoints: List<DataPoint>,
     val macros: List<MacroConfig> = emptyList()
 )
@@ -18,7 +19,8 @@ data class DataPoint(
     val formula: String? = null,
     val addresses: Map<String, String> = emptyMap(),
     val pointer: Map<String, String>? = null,
-    val offset: String? = null
+    val offset: String? = null,
+    val offsets: List<String>? = null
 )
 
 data class MacroConfig(


### PR DESCRIPTION
- Add configurable idSize to ConsoleConfig for PSP's 9-byte game IDs
- Implement multi-level pointer chain resolution with platform-aware byte order (little-endian for PSP, big-endian for GCN/WII)
- Add u32_le and float_le value types for little-endian memory parsing
- Add gameIds field to ProfileConfig for explicit game ID matching
- Add resolveProfileId() to ConfigManager with gameIds lookup and prefix-matching fallback for backward compatibility
- Rewrite theme filtering and auto-selection in MainViewModel to use profile resolution instead of naive prefix matching
- Fix SyncService repo URL to support arbitrary branch names via regex
- Add MAX_POINTER_CHAIN_DEPTH constant to guard chain traversal